### PR TITLE
Amended changes for PR

### DIFF
--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -3440,7 +3440,7 @@ CosaDmlEthInit(
         }
     }
 #else
-    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)
 
     char wanPhyName[20] = {0},out_value[20] = {0};
 

--- a/source/TR-181/board_sbapi/cosa_ethernet_manager.c
+++ b/source/TR-181/board_sbapi/cosa_ethernet_manager.c
@@ -375,7 +375,7 @@ static ethSmState_t Transition_EthWanLinkFound(PETH_SM_PRIVATE_INFO pstInfo)
 #if defined(FEATURE_RDKB_WAN_AGENT)
     if (ANSC_STATUS_SUCCESS != CosaDmlEthCreateEthLink(pstInfo->Name, stGlobalInfo.Path))
 #elif defined(FEATURE_RDKB_WAN_MANAGER)
-    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)
     CHAR wanPhyName[20] = {0},out_value[20] = {0};
     if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
     {


### PR DESCRIPTION
Reason for Change : To bringup wan interface - erouter0 for QCOM Platform.
Test Procedure: Flash the image and check if wan interface - erouter0 is up.
Risks: Medium
Priority: P1